### PR TITLE
Fix API key recovery from $_SESSION variable

### DIFF
--- a/src/Api/Client.php
+++ b/src/Api/Client.php
@@ -102,10 +102,10 @@ class Client
     private function setApiKey()
     {
         if (isset($_SESSION)) {
-            if (!isset($_SESSION[self::CHILI_SESSION])) {
-                $_SESSION[self::CHILI_SESSION] = $this->apiKey = $this->generateApiKey();
-            } else {
+            if (isset($_SESSION[self::CHILI_SESSION]) && !empty($_SESSION[self::CHILI_SESSION])) {
                 $this->apiKey = $_SESSION[self::CHILI_SESSION];
+            } else {
+                $_SESSION[self::CHILI_SESSION] = $this->apiKey = $this->generateApiKey();
             }
         } else {
             $this->apiKey = $this->generateApiKey();


### PR DESCRIPTION
If, for any reason, the session variable is set to an empty value, the API key is generated again, to avoid being provided empty for the API call.