### PR TITLE
Allow/disallow workspace administration explicitly

### DIFF
--- a/src/Service/Resource/Documents.php
+++ b/src/Service/Resource/Documents.php
@@ -56,13 +56,12 @@ class Documents extends AbstractResourceService
         $forAnonymousUser = false
     )
     {
-        if ($allowWorkspaceAdministration) {
-            $this->client->setWorkspaceAdministration(
-                array(
-                    'allowWorkspaceAdministration' => $allowWorkspaceAdministration
-                )
-            );
-        }
+        // Allow/disallow workspace administration explicitly (do not rely on default behaviour)
+        $this->client->setWorkspaceAdministration(
+            array(
+                'allowWorkspaceAdministration' => $allowWorkspaceAdministration
+            )
+        );
 
         $params = array(
             'itemID' => $itemID,


### PR DESCRIPTION
Call setWorkspaceAdministration web service method even if allowWorkspaceAdministration is false ; this allows to enable end user view of the workspace 